### PR TITLE
Replace deprecated GetServerVarAsString

### DIFF
--- a/announce.pwn
+++ b/announce.pwn
@@ -29,7 +29,7 @@ public OnFilterScriptInit()
 
 stock GetIP(ip[], const len)
 {
-    GetServerVarAsString("bind", ip, len);
+    GetConsoleVarAsString("bind", ip, len);
 }
 
 forward Announce();


### PR DESCRIPTION
To avoid future compatibility or deprecation warning issues. GetConsoleVarAsString is otherwise identical.